### PR TITLE
Cast atoms as atoms

### DIFF
--- a/lib/exnumerable.ex
+++ b/lib/exnumerable.ex
@@ -9,8 +9,8 @@ defmodule Exnumerator do
 
       if Enum.all?(values, &(is_atom(&1))) do
         for value <- values, atom = value, string = Atom.to_string(value) do
-          def cast(unquote(atom)),   do: {:ok, unquote(string)}
-          def cast(unquote(string)), do: {:ok, unquote(string)}
+          def cast(unquote(atom)),   do: {:ok, unquote(atom)}
+          def cast(unquote(string)), do: {:ok, unquote(atom)}
           def load(unquote(string)), do: {:ok, unquote(atom)}
           def dump(unquote(string)), do: {:ok, unquote(string)}
           def dump(unquote(atom)),   do: {:ok, unquote(string)}

--- a/test/exnumerable_test.exs
+++ b/test/exnumerable_test.exs
@@ -33,7 +33,7 @@ defmodule ExnumeratorTest do
   end
 
   test "should argument given types(MessageAsAtoms)" do
-    assert MessageAsAtom.cast(:sent)      == {:ok, "sent"}
+    assert MessageAsAtom.cast(:sent)      == {:ok, :sent}
     assert MessageAsAtom.dump(:delivered) == {:ok, "delivered"}
   end
 
@@ -54,7 +54,7 @@ defmodule ExnumeratorTest do
   end
 
   test "should accept string for values in atom for cast and dump" do
-    assert MessageAsAtom.cast("sent")      == {:ok, "sent"}
+    assert MessageAsAtom.cast("sent")      == {:ok, :sent}
     assert MessageAsAtom.dump("delivered") == {:ok, "delivered"}
   end
 


### PR DESCRIPTION
Currently, atom enums are _loaded_ as atoms from the database, but on
insert, they are converted to strings.

```elixir
Repo.insert!(%Message{status: :sent})

%Message{
  status: "sent"
}
```

With this change, they will remain atoms as they should:

```elixir
Repo.insert!(%Message{status: :sent})

%Message{
  status: :sent
}
```